### PR TITLE
Refactor image saving logic to use BGR color space

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
                     norm_img_path = os.path.join(args.output_dir, os.path.relpath(img_path, args.target_dir))
                     # replace the extension, jpg for efficient compression, png for lossless compression
                     norm_img_path = norm_img_path.replace('.png', '.jpg')
-                    cv2.imwrite(norm_img_path, norm_img)
+                    cv2.imwrite(norm_img_path, cv2.cvtColor(norm_img, cv2.COLOR_RGB2BGR))
                     info = 'Processing {} / {} Time elapse {:.2f} s'.format(idx, length, time.time()-tic)
                     print(info)
                     idx += 1


### PR DESCRIPTION
In your code, you use 'cv2.cvtColor(im, cv2.COLOR_BGR2RGB)' when you use your function 'read_image()' to read images.However, you didn't use  'cv2.cvtColor(norm_img, cv2.COLOR_RGB2BGR)'  when you save normalized images,this results in the normalized image having a purplish color and can't get the correct color distribution